### PR TITLE
Fix tetris line score bug

### DIFF
--- a/classics/src/tetris.c
+++ b/classics/src/tetris.c
@@ -100,7 +100,7 @@ static bool ResolveLateralMovement();
 static bool ResolveTurnMovement();
 static void CheckDetection(bool *detection);
 static void CheckCompletion(bool *lineToDelete);
-static void DeleteCompleteLines();
+static int DeleteCompleteLines();
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -279,11 +279,12 @@ void UpdateGame(void)
 
                 if (fadeLineCounter >= FADING_TIME)
                 {
-                    DeleteCompleteLines();
+                    int deletedLines = 0;
+                    deletedLines = DeleteCompleteLines();
                     fadeLineCounter = 0;
                     lineToDelete = false;
 
-                    lines++;
+                    lines += deletedLines;
                 }
             }
         }
@@ -758,8 +759,10 @@ static void CheckCompletion(bool *lineToDelete)
     }
 }
 
-static void DeleteCompleteLines()
+static int DeleteCompleteLines()
 {
+    int deletedLines = 0;
+
     // Erase the completed line
     for (int j = GRID_VERTICAL_SIZE - 2; j >= 0; j--)
     {
@@ -786,6 +789,10 @@ static void DeleteCompleteLines()
                     }
                 }
             }
+
+             deletedLines++;
         }
     }
+
+    return deletedLines;
 }


### PR DESCRIPTION
There is a bug in the Tetris classic game. If you manage to place the pieces in such a way where more than one line is going to be deleted, then the game indeed deleted the correct amount of lines but it doesn't update the score appropriately. The score lines are only updated by 1 increment. This PR addresses this issue.