### PR TITLE
Remove redudant code from arkanoid

### DIFF
--- a/classics/src/arkanoid.c
+++ b/classics/src/arkanoid.c
@@ -32,8 +32,6 @@
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
-typedef enum GameScreen { LOGO, TITLE, GAMEPLAY, ENDING } GameScreen;
-
 typedef struct Player {
     Vector2 position;
     Vector2 size;


### PR DESCRIPTION
There is a `typedef enum` defined at the beginning, but it's never been used. It fits no purpose in the game as it is at the moment.