### PR TITLE
Fix Ball Height Bug

### DIFF
--- a/classics/src/arkanoid.c
+++ b/classics/src/arkanoid.c
@@ -124,7 +124,7 @@ void InitGame(void)
     player.life = PLAYER_MAX_LIFE;
 
     // Initialize ball
-    ball.position = (Vector2){ screenWidth/2, screenHeight*7/8 - 30 };
+    ball.position = (Vector2){ player.position.x, player.position.y - player.size.y/2 - ball.radius };
     ball.speed = (Vector2){ 0, 0 };
     ball.radius = 7;
     ball.active = false;
@@ -175,7 +175,7 @@ void UpdateGame(void)
             }
             else
             {
-                ball.position = (Vector2){ player.position.x, screenHeight*7/8 - 30 };
+                ball.position = (Vector2){ player.position.x, player.position.y - player.size.y/2 - ball.radius };
             }
 
             // Collision logic: ball vs walls


### PR DESCRIPTION
This is to fix a bug where the ball when it was in the inactive state floated above the paddle instead of sitting flush.

Before:

![image](https://github.com/raysan5/raylib-games/assets/22916974/830704e4-52f6-46c0-8e7a-0531a73b5eb4)

After:

![image](https://github.com/raysan5/raylib-games/assets/22916974/9a9913cc-e341-4635-961b-de49412bb5bc)
